### PR TITLE
Add UUID generation tests and fix timestamp format

### DIFF
--- a/src/uuid.cpp
+++ b/src/uuid.cpp
@@ -24,8 +24,8 @@ GenerateUuid()
         rng.seed(static_cast<unsigned int>(nanos_since_epoch.count()));
 
         uuid << std::hex;
-        
-        uuid << udist(rng) << "_" << udist(rng) << "_" << nanos_since_epoch.count();
+
+        uuid << udist(rng) << "_" << udist(rng) << "_" << std::dec << nanos_since_epoch.count();
 
         // TODO: Consider hashing the whole thing
 

--- a/tests/uuid_test.cpp
+++ b/tests/uuid_test.cpp
@@ -1,0 +1,31 @@
+#include "uuid.hpp"
+#include <regex>
+#include <unordered_set>
+#include <cassert>
+#include <iostream>
+
+void TestUuidPattern()
+{
+        std::string uuid = GenerateUuid();
+        std::regex pattern("^[0-9a-f]+_[0-9a-f]+_[0-9]+$");
+        assert(std::regex_match(uuid, pattern));
+}
+
+void TestUuidCollisions()
+{
+        const int iterations = 10000;
+        std::unordered_set<std::string> uuids;
+        for (int i = 0; i < iterations; ++i) {
+                auto uuid = GenerateUuid();
+                bool inserted = uuids.insert(uuid).second;
+                assert(inserted);
+        }
+}
+
+int main()
+{
+        TestUuidPattern();
+        TestUuidCollisions();
+        std::cout << "UUID tests passed" << std::endl;
+        return 0;
+}


### PR DESCRIPTION
## Summary
- add tests ensuring `GenerateUuid` outputs `[hex]_[hex]_[digits]` and has no collisions
- make `GenerateUuid` use decimal timestamp to match expected format

## Testing
- `g++ -std=c++17 -Isrc tests/uuid_test.cpp src/uuid.cpp -o uuid_test`
- `./uuid_test`


------
https://chatgpt.com/codex/tasks/task_e_68b392a31bac832881f01f2e60d05a96